### PR TITLE
Remove dependency on bun

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,11 @@ runs:
       run: npm install -g @augmentcode/auggie
       shell: bash
     - name: Run Augment Agent
-      run: node --experimental-strip-types $GITHUB_ACTION_PATH/src/index.ts
+      run: |
+        cd $GITHUB_ACTION_PATH
+        npm install
+        npx tsc
+        node dist/index.js
       shell: bash
       env:
         INPUT_AUGMENT_SESSION_AUTH: ${{ inputs.augment_session_auth }}

--- a/action.yml
+++ b/action.yml
@@ -64,10 +64,7 @@ runs:
       run: |
         cd $GITHUB_ACTION_PATH
         npm install
-        npx tsc
-        ls
-        ls dist
-        node dist/index.js
+        node --experimental-strip-types src/index.ts
       shell: bash
       env:
         INPUT_AUGMENT_SESSION_AUTH: ${{ inputs.augment_session_auth }}

--- a/action.yml
+++ b/action.yml
@@ -60,12 +60,8 @@ runs:
     - name: Setup Auggie
       run: npm install -g @augmentcode/auggie
       shell: bash
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
-      with:
-        bun-version: latest
     - name: Run Augment Agent
-      run: bun run $GITHUB_ACTION_PATH/src/index.ts
+      run: npm run $GITHUB_ACTION_PATH/src/index.ts
       shell: bash
       env:
         INPUT_AUGMENT_SESSION_AUTH: ${{ inputs.augment_session_auth }}

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,9 @@ runs:
     - name: Setup Auggie
       run: npm install -g @augmentcode/auggie
       shell: bash
+    - name: Test list directory
+      run: ls
+      shell: bash
     - name: Run Augment Agent
       run: npm run $GITHUB_ACTION_PATH/src/index.ts
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -60,11 +60,8 @@ runs:
     - name: Setup Auggie
       run: npm install -g @augmentcode/auggie
       shell: bash
-    - name: Test list directory
-      run: ls
-      shell: bash
     - name: Run Augment Agent
-      run: npm run $GITHUB_ACTION_PATH/src/index.ts
+      run: node --experimental-strip-types $GITHUB_ACTION_PATH/src/index.ts
       shell: bash
       env:
         INPUT_AUGMENT_SESSION_AUTH: ${{ inputs.augment_session_auth }}

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,8 @@ runs:
         cd $GITHUB_ACTION_PATH
         npm install
         npx tsc
+        ls
+        ls dist
         node dist/index.js
       shell: bash
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,334 @@
+{
+  "name": "augment-agent",
+  "version": "0.1.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "augment-agent",
+      "version": "0.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.10.1",
+        "@octokit/rest": "^20.0.2",
+        "nunjucks": "^3.2.4",
+        "yaml": "^2.3.4",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@types/node": "^22.16.4",
+        "@types/nunjucks": "^3.2.6",
+        "prettier": "^3.6.2",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "bun": ">=1.0.0",
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.4-cjs.2",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.2-cjs.1",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.16.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "license": "MIT"
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "license": "ISC"
+    },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "license": "ISC"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Remove Bun runtime dependency from GitHub Action

This PR simplifies the action setup by removing the Bun runtime dependency and switching to npm for execution.

**Changes:**
- Remove the `Setup Bun` step from the workflow
- Replace `bun run` with `npm run` for executing the action script

**Impact:**
Reduces external dependencies and simplifies the action's setup process, making it easier to maintain and potentially faster to initialize.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*